### PR TITLE
Add .jp support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Whoiser change log
 
+####
+
+- Updated - Parse WHOIS for .jp domains.
+
 #### 1.10.0 - 13 April 2021
 - Updated - Parse WHOIS for co.ua/biz.ua domains; improve parsing for other .ua domains [#32](https://github.com/LayeredStudio/whoiser/pull/32) (thanks to @EPolishchuk)
 - Updated - Detect & remove more redacted whois text

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -271,6 +271,10 @@ const parseDomainWhois = (domain, whois) => {
 		colon = uaColonFormat
 	}
 
+	if (domain.endsWith('.jp')) {
+		lines = handleJpLines(lines)
+	}
+
 	lines = lines.map((l) => l.trim())
 
 	lines.forEach((line) => {
@@ -385,6 +389,27 @@ const handleMultiLines = (lines) => {
 	})
 
 	return lines
+}
+
+// Handle formats like this:
+// [Name Server]                   ns1.jprs.jp
+// [Name Server]                   ns2.jprs.jp
+const handleJpLines = (lines) => {
+	const ret = []
+	while (lines.length > 0) {
+		const line = lines.shift()
+		if (line.startsWith("[ ")) {
+			// skip
+		} else if (line.startsWith("[")) {
+			ret.push(line)
+		} else if (line.startsWith(" ")) {
+			const prev = ret.pop()
+			ret.push(prev + "\n" + line.trim())
+		} else {
+			// skip
+		}
+	}
+	return ret.map((line) => line.replace(/\[(.*?)\]/g, '$1:'))
 }
 
 module.exports.parseSimpleWhois = parseSimpleWhois

--- a/src/whoiser.js
+++ b/src/whoiser.js
@@ -95,6 +95,9 @@ const whoisDomain = async (domain, { host = null, timeout = 15000, follow = 2, r
 		if (host === 'whois.denic.de') {
 			query = `-T dn ${query}`
 		}
+		if (host === 'whois.jprs.jp') {
+			query = `${query}/e`
+		}
 
 		try {
 			resultRaw = await whoisQuery({ host, query, timeout })

--- a/test/domains.js
+++ b/test/domains.js
@@ -70,6 +70,12 @@ describe('#whoiser.domain()', function() {
 			assert.equal(whois['whois.domain-registry.nl']['Name Server'].length, 4, 'Incorrect number of NS returned')
 		});
 
+		it('returns WHOIS for "jprs.jp"', async function() {
+			let whois = await whoiser.domain('jprs.jp')
+			assert.equal(whois['whois.jprs.jp']['Domain Name'], 'JPRS.JP', 'Domain name doesn\'t match')
+			assert.equal(whois['whois.jprs.jp']['Name Server'].length, 4, 'Incorrect number of NS returned')
+		});
+
 		it('returns WHOIS for "nic.co.ua" with all fields', async function() {
 			let whois = await whoiser.domain('nic.co.ua')
 			assert.equal(whois['whois.ua']['Domain Name'], 'NIC.CO.UA', 'Domain name doesn\'t match')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| Deprecations? | no
| License       | MIT

Unfortunately, .jp whois returns non-standard format.  Add simple function to parse these output.