### PR TITLE
Add .NYC TLD Support

### DIFF
--- a/src/whoiser.js
+++ b/src/whoiser.js
@@ -12,6 +12,7 @@ let cacheTldWhoisServer = {
 	org: 'whois.pir.org',
 	co: 'whois.nic.co',
 	shop: 'whois.nic.shop',
+	nyc: 'whois.nic.nyc',
 }
 
 // misspelled whois servers..

--- a/test/domains.js
+++ b/test/domains.js
@@ -78,6 +78,12 @@ describe('#whoiser.domain()', function() {
 			assert.equal(whois['whois.jprs.jp']['Name Server'].length, 4, 'Incorrect number of NS returned')
 		});
 
+		it('returns WHOIS for "ownit.nyc"', async function() {
+			let whois = await whoiser.domain('ownit.nyc')
+			assert.equal(whois['whois.nic.nyc']['Domain Name'], 'ownit.nyc', 'Domain name doesn\'t match')
+			assert.equal(whois['whois.nic.nyc']['Name Server'].length, 6, 'Incorrect number of NS returned')
+		});
+
 		it('returns WHOIS for "nic.ua" with fieldsfor all type of contacts', async function() {
 			let whois = await whoiser.domain('nic.ua')
 			assert.equal(whois['whois.ua']['Domain Name'], 'nic.ua', 'Domain name doesn\'t match')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

This pull request is for adding .NYC support by manually adding the WHOIS server to the cache/presets. For some reason IANA is not returning the WHOIS server for this TLD. 