### PR TITLE
Third Level Domains, Additional TLDs, & Bug Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Added - Support for third level domains [#80](https://github.com/LayeredStudio/whoiser/pull/80)
 - Added - Additional support for TLDs not in the IANA database [#80](https://github.com/LayeredStudio/whoiser/pull/80)
+- Fixed - Follow RIPE referrals [#80](https://github.com/LayeredStudio/whoiser/pull/80)
+- Fixed - Parse .gg, .je, and .as whois data correctly [#80](https://github.com/LayeredStudio/whoiser/pull/80)
 
 #### 1.13.2 - 28 November 2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Whoiser change log
 
+#### 1.13.3 - 1 December 2022
+
+- Added - Support for third level domains [#80](https://github.com/LayeredStudio/whoiser/pull/80)
+- Added - Additional support for TLDs not in the IANA database [#80](https://github.com/LayeredStudio/whoiser/pull/80)
+
 #### 1.13.2 - 28 November 2022
 
 - Updated - Include more WHOIS servers in lib, speeds-up domain WHOIS queries

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "whoiser",
-  "version": "1.13.2",
+  "version": "1.13.3",
   "description": "Whois info for TLDs, domains and IPs",
   "types": "./index.d.ts",
   "typings": "./index.d.ts",

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -267,8 +267,12 @@ const parseDomainWhois = (domain, whois) => {
 
 	// Parse WHOIS info for specific TLDs
 
-	if (domain.endsWith('.uk') || domain.endsWith('.be') || domain.endsWith('.nl') || domain.endsWith('.eu') || domain.endsWith('.ly') || domain.endsWith('.mx')) {
+	if (domain.endsWith('.uk') || domain.endsWith('.be') || domain.endsWith('.nl') || domain.endsWith('.eu') || domain.endsWith('.ly') || domain.endsWith('.mx')|| domain.endsWith('.gg')) {
 		lines = handleMultiLines(lines)
+	}
+
+	if (domain.endsWith('.gg')) {
+		lines = handleMissingColons(lines)
 	}
 
 	if (domain.endsWith('.ua')) {
@@ -420,6 +424,18 @@ const handleJpLines = (lines) => {
 		}
 	}
 	return ret.map((line) => line.replace(/\[(.*?)\]/g, '$1:'))
+}
+
+// Handle formats like this:
+// Registrar Gandi SAS
+const handleMissingColons = (lines) => {
+	lines.forEach((line, index) => {
+		if (line.startsWith('Registrar ')) {
+			lines[index] = line.replace('Registrar ', 'Registrar: ')
+		}
+	})
+
+	return lines
 }
 
 module.exports.parseSimpleWhois = parseSimpleWhois

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -265,7 +265,6 @@ const parseDomainWhois = (domain, whois) => {
 		.split('\n')
 		.map((line) => line.replace('\t', '  '))
 
-
 	// Parse WHOIS info for specific TLDs
 
 	if (domain.endsWith('.uk') || domain.endsWith('.be') || domain.endsWith('.nl') || domain.endsWith('.eu') || domain.endsWith('.ly') || domain.endsWith('.mx')) {
@@ -307,14 +306,12 @@ const parseDomainWhois = (domain, whois) => {
 			if (data[label] && Array.isArray(data[label])) {
 				data[label].push(value)
 			} else if (!ignoreLabels.includes(label.toLowerCase()) && !ignoreTexts.some((text) => label.toLowerCase().includes(text))) {
-
 				// WHOIS field already exists, if so append data
 				if (data[label] && data[label] !== value) {
 					data[label] = `${data[label]} ${value}`.trim()
 				} else {
 					data[label] = value
 				}
-
 			} else {
 				text.push(line)
 			}
@@ -411,13 +408,13 @@ const handleJpLines = (lines) => {
 			line = line.replace(/^[a-z]. \[/, '[')
 		}
 
-		if (line.startsWith("[ ")) {
+		if (line.startsWith('[ ')) {
 			// skip
-		} else if (line.startsWith("[")) {
+		} else if (line.startsWith('[')) {
 			ret.push(line)
-		} else if (line.startsWith(" ")) {
+		} else if (line.startsWith(' ')) {
 			const prev = ret.pop()
-			ret.push(prev + "\n" + line.trim())
+			ret.push(prev + '\n' + line.trim())
 		} else {
 			// skip
 		}

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -267,7 +267,17 @@ const parseDomainWhois = (domain, whois) => {
 
 	// Parse WHOIS info for specific TLDs
 
-	if (domain.endsWith('.uk') || domain.endsWith('.be') || domain.endsWith('.nl') || domain.endsWith('.eu') || domain.endsWith('.ly') || domain.endsWith('.mx') || domain.endsWith('.gg') || domain.endsWith('.je') || domain.endsWith('.as')) {
+	if (
+		domain.endsWith('.uk') ||
+		domain.endsWith('.be') ||
+		domain.endsWith('.nl') ||
+		domain.endsWith('.eu') ||
+		domain.endsWith('.ly') ||
+		domain.endsWith('.mx') ||
+		domain.endsWith('.gg') ||
+		domain.endsWith('.je') ||
+		domain.endsWith('.as')
+	) {
 		lines = handleMultiLines(lines)
 	}
 

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -267,11 +267,11 @@ const parseDomainWhois = (domain, whois) => {
 
 	// Parse WHOIS info for specific TLDs
 
-	if (domain.endsWith('.uk') || domain.endsWith('.be') || domain.endsWith('.nl') || domain.endsWith('.eu') || domain.endsWith('.ly') || domain.endsWith('.mx')|| domain.endsWith('.gg')) {
+	if (domain.endsWith('.uk') || domain.endsWith('.be') || domain.endsWith('.nl') || domain.endsWith('.eu') || domain.endsWith('.ly') || domain.endsWith('.mx') || domain.endsWith('.gg') || domain.endsWith('.je') || domain.endsWith('.as')) {
 		lines = handleMultiLines(lines)
 	}
 
-	if (domain.endsWith('.gg')) {
+	if (domain.endsWith('.gg') || domain.endsWith('.je') || domain.endsWith('.as')) {
 		lines = handleMissingColons(lines)
 	}
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,12 +2,12 @@ const punycode = require('punycode')
 const https = require('https')
 const splitStringBy = (string, by) => [string.slice(0, by), string.slice(by + 1)]
 
-const requestGetBody = url => {
+const requestGetBody = (url) => {
 	return new Promise((resolve, reject) => {
 		https
-			.get(url, resp => {
+			.get(url, (resp) => {
 				let data = ''
-				resp.on('data', chunk => (data += chunk))
+				resp.on('data', (chunk) => (data += chunk))
 				resp.on('end', () => resolve(data))
 				resp.on('error', reject)
 			})
@@ -15,7 +15,7 @@ const requestGetBody = url => {
 	})
 }
 
-const isTld = tld => {
+const isTld = (tld) => {
 	if (tld.startsWith('.')) {
 		tld = tld.substring(1)
 	}
@@ -23,15 +23,12 @@ const isTld = tld => {
 	return /^([a-z]{2,64}|xn[a-z0-9-]{5,})$/i.test(punycode.toASCII(tld))
 }
 
-const isDomain = domain => {
+const isDomain = (domain) => {
 	if (domain.endsWith('.')) {
 		domain = domain.substring(0, domain.length - 1)
 	}
 
-	const labels = punycode
-		.toASCII(domain)
-		.split('.')
-		.reverse()
+	const labels = punycode.toASCII(domain).split('.').reverse()
 	const labelTest = /^([a-z0-9-]{1,64}|xn[a-z0-9-]{5,})$/i
 
 	return (

--- a/src/whoiser.js
+++ b/src/whoiser.js
@@ -103,7 +103,7 @@ const whoisTld = async (query, { timeout = 15000, raw = false, domainThirdLevel 
 		data.__raw = result
 	}
 
-	if (!data.domain || !data.domain.length) {
+	if (!data.domain || !data.domain.length || !data.whois) {
 		const whois = await whoisTldAlternate(domainTld) // Query alternate sources
 		if (whois)
 			return {

--- a/src/whoiser.js
+++ b/src/whoiser.js
@@ -87,11 +87,14 @@ const whoisTld = async (query, { timeout = 15000, raw = false, domainThirdLevel 
 	// Check for 3rd level domain
 	if (domainThirdLevel) {
 		let [_, secondTld] = domainName && splitStringBy(domainName, domainName.lastIndexOf('.')) // Parse 3rd level domain
-		const whois = await whoisTldAlternate(secondTld ? `${secondTld}.${domainTld}` : query) // Query alternate sources
+		const finalTld = secondTld ? `${secondTld}.${domainTld}` : query
+
+		const whois = await whoisTldAlternate(finalTld) // Query alternate sources
 		if (whois)
 			return {
 				refer: whois,
 				domain: domainName,
+				finalTld,
 				whois,
 			} // Return alternate whois data
 	}
@@ -138,7 +141,7 @@ const whoisDomain = async (domain, { host = null, timeout = 15000, follow = 2, r
 		}
 
 		host = tld.whois
-		cacheTldWhoisServer[domainTld] = tld.whois
+		cacheTldWhoisServer[tld.finalTld || domainTld] = tld.whois
 	}
 
 	// query WHOIS servers for data

--- a/test/domains.js
+++ b/test/domains.js
@@ -12,6 +12,14 @@ describe('#whoiser.domain()', function() {
 			assert.equal(firstWhois['Registry Domain ID'], '27CAA9F68-GOOGLE', 'Registry Domain ID doesn\'t match')
 		});
 
+		it('returns WHOIS for "google.co.uk"', async function() {
+			const whois = await whoiser.domain('google.co.uk')
+			const firstWhois = whoiser.firstResult(whois)
+
+			assert.equal(firstWhois['Domain Name'], 'google.co.uk', 'Domain name doesn\'t match')
+			assert.equal(firstWhois['Created Date'], '14-Feb-1999', 'Created Date doesn\'t match')
+		});
+
 		it('returns WHOIS for "cloudflare.com" from "whois.cloudflare.com" server (host option)', async function() {
 			let whois = await whoiser.domain('cloudflare.com', {host: 'whois.cloudflare.com'})
 			assert.equal(Object.values(whois).length, 1, 'Has less or more than 1 WHOIS result')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | Yes <!-- please update README.md and CHANGELOG.md files -->
| Deprecations? | No <!-- please update UPGRADE.md and CHANGELOG.md files -->
| License       | MIT

Adds more queries to get whois servers with DNS if they don't exist in the IANA database. (third level domains and other obscure TLDs) Also adds support for looking up third level domains such as .co.uk. I did use optional chaining if that is an issue for supporting older node.js versions.

Also fixes .gg, .je, and .as whois results as they use new lines and have a weird registrar field. Closes #50 
Now follows referral server for the RIPE database. Closes #72 
