### PR TITLE
Improved parser for TLD .it

### DIFF
--- a/src/parsers.js
+++ b/src/parsers.js
@@ -280,6 +280,10 @@ const parseDomainWhois = (domain, whois) => {
 	if (domain.endsWith('.jp')) {
 		lines = handleJpLines(lines)
 	}
+	
+	if (domain.endsWith('.it')) {
+		lines = handleDotIt(lines)
+	}
 
 	lines = lines.map((l) => l.trim())
 
@@ -355,6 +359,40 @@ const handleDotUa = (lines) => {
 		} else if (!line.startsWith('%') && line.includes(': ')) {
 			if (line.startsWith('registrar')) line = 'id'
 			lines[index] = flag + ' ' + line
+		}
+	})
+	return lines
+}
+
+const handleDotIt = (lines) => {
+	lines.forEach((line, index) => {
+		if (line == 'Registrar' || line == 'Nameservers') {
+			// Check next lines
+			for (let i = 1; i <= 5; i++) {
+				// if no line or empty line
+				if (!lines[index + i] || !lines[index + i].trim().length) {
+					break
+				}
+
+				// if tabbed line or line with value only, prefix the line with main label
+				if ((lines[index + i].startsWith('  ') && lines[index + i].includes(': ')) || !lines[index + i].endsWith(':')) {
+					let label = line.trim()
+					if (label == 'Nameservers') {
+						label = "Name Server:"
+					}
+
+					if (lines[index + i].includes(':') && label.endsWith(':')) {
+						label = label.slice(0, -1)
+					}
+
+					lines[index + i] = label + ' ' + lines[index + i].replace('\t', ' ').trim()
+					addedLabel = true
+				}
+			}
+			// remove this line if it was just a label for other lines
+			if (addedLabel) {
+				lines[index] = ''
+			}
 		}
 	})
 	return lines

--- a/test/domains.js
+++ b/test/domains.js
@@ -92,6 +92,13 @@ describe('#whoiser.domain()', function() {
 			assert.notStrictEqual(whois['whois.ua']['administrative contacts organization-loc'], false, 'Does not return admin name')
 			assert.notStrictEqual(whois['whois.ua']['technical contacts organization-loc'], false, 'Does not return tech name')
 		});
+		
+		it('returns WHOIS for "google.it"', async function() {
+			let whois = await whoiser.domain('google.it')
+			assert.equal(whois['whois.nic.it']['Domain Name'], 'google.it', 'Domain name doesn\'t match')
+			assert.equal(whois['whois.nic.it']['Name Server'].length, 4, 'Incorrect number of NS returned')
+			assert.equal(whois['whois.nic.it']['Registrar'], 'MarkMonitor International Limited MARKMONITOR-REG', 'Registrar name doesn\'t match')
+		});
 	});
 
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no<!-- please update README.md and CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE.md and CHANGELOG.md files -->
| License       | MIT

Added handler for TLD .it to correctly parse name servers and organization name/registrar name which in the current version are merged into a single "Organization" line

Old parser
```json
"Name Server":[],
"Organization":"Google Ireland Holdings Unlimited Company Google LLC Google LLC MarkMonitor International Limited",
"Registrar": "line missing"
```

New parser
```json
"Name Server":["ns1.google.com","ns2.google.com","ns3.google.com","ns4.google.com"],
"Organization":"Google Ireland Holdings Unlimited Company Google LLC Google LLC",
"Registrar":"MarkMonitor International Limited MARKMONITOR-REG"
```