### PR TITLE
Uses raw domain for .de TLD

### DIFF
--- a/src/whoiser.js
+++ b/src/whoiser.js
@@ -120,8 +120,8 @@ const whoisTld = async (query, { timeout = 15000, raw = false, domainThirdLevel 
 	return data
 }
 
-const whoisDomain = async (domain, { host = null, timeout = 15000, follow = 2, raw = false } = {}) => {
-	domain = punycode.toASCII(domain)
+const whoisDomain = async (rawDomain, { host = null, timeout = 15000, follow = 2, raw = false } = {}) => {
+	domain = punycode.toASCII(rawDomain)
 	const domainThirdLevel = domain.lastIndexOf('.') !== domain.indexOf('.')
 	const [domainName, domainTld] = splitStringBy(domain.toLowerCase(), domain.lastIndexOf('.'))
 	let results = {}
@@ -151,7 +151,7 @@ const whoisDomain = async (domain, { host = null, timeout = 15000, follow = 2, r
 
 		// hardcoded WHOIS queries..
 		if (host === 'whois.denic.de') {
-			query = `-T dn ${query}`
+			query = `-T dn ${rawDomain}`
 		}
 		if (host === 'whois.jprs.jp') {
 			query = `${query}/e`

--- a/test/domains.js
+++ b/test/domains.js
@@ -46,6 +46,12 @@ describe('#whoiser.domain()', function() {
 		});
 		*/
 
+		it('should return WHOIS for "de" when domain includes an umlaut', async function () {
+			// https://github.com/LayeredStudio/whoiser/issues/93
+			const whois = await whoiser.domain('testä.de', { follow: 1 })
+			assert.notEqual(whois['whois.denic.de']['Domain Status'], 'invalid', 'Domain Status is reported as invalid')
+		});
+
 		it('returns WHOIS for "netflix.io" with correct registrar WHOIS server', async function() {
 			let whois = await whoiser.domain('netflix.io', {follow: 1})
 			assert.equal(whois['whois.nic.io']['Registrar WHOIS Server'], 'whois.markmonitor.com', 'Parsing error for WHOIS server')


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update README.md and CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE.md and CHANGELOG.md files -->
| Tickets       | Fix #93 <!-- prefix each issue number with "Fix #", if any -->
| License       | MIT

Uses the raw domain input, rather than punycode format, for whois.denic.de as this results in valid responses.