### PR TITLE
Adding a new option to show/hide WHOIS protected data in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Get WHOIS info for domains.
 	- `timeout` - WHOIS server request timeout in ms. Default: 1500
 	- `follow` - How many WHOIS server to query. 1 = registry server (faster), 2 = registry + registrar (more domain details). Default: 2
 	- `raw` - Return the raw WHOIS result in response. Added to `__raw`
+	- `ignorePrivacy` - Show or hide the WHOIS protected data from response, accepts boolean. Default: true
 
 ```js
 const whoiser = require('whoiser');

--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,13 @@ declare module 'whoiser' {
 		 * @default '\r\n'
 		 */
 		querySuffix?: string
+
+		/**
+		 * Ignore the protected WHOIS data from response
+		 * and eplace them with empty values
+		 * @default true
+		 */
+		ignorePrivacy?: boolean
 	}
 
 	export type OptionsIp = Pick<Options, 'host' | 'timeout' | 'raw'>

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -109,7 +109,7 @@ const parseSimpleWhois = (whois) => {
 	return data
 }
 
-const parseDomainWhois = (domain, whois) => {
+const parseDomainWhois = (domain, whois, ignorePrivacy) => {
 	// Text saying there's no useful data in a field
 	const noData = [
 		'-',
@@ -317,7 +317,7 @@ const parseDomainWhois = (domain, whois) => {
 			}
 
 			// remove redacted data
-			if (noData.includes(value.toLowerCase())) {
+			if (ignorePrivacy && noData.includes(value.toLowerCase())) {
 				value = ''
 			}
 

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -109,7 +109,7 @@ const parseSimpleWhois = (whois) => {
 	return data
 }
 
-const parseDomainWhois = (domain, whois, ignorePrivacy = true) => {
+const parseDomainWhois = (domain, whois, ignorePrivacy) => {
 	// Text saying there's no useful data in a field
 	const noData = [
 		'-',

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -272,6 +272,7 @@ const parseDomainWhois = (domain, whois, ignorePrivacy) => {
 		.trim()
 		.split('\n')
 		.map((line) => line.replace('\t', '  '))
+		.map((line) => line.replace(/[><]\W+/g, ''))
 
 	// Parse WHOIS info for specific TLDs
 
@@ -301,7 +302,7 @@ const parseDomainWhois = (domain, whois, ignorePrivacy) => {
 	if (domain.endsWith('.jp')) {
 		lines = handleJpLines(lines)
 	}
-	
+
 	if (domain.endsWith('.it')) {
 		lines = handleDotIt(lines)
 	}

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -272,7 +272,6 @@ const parseDomainWhois = (domain, whois, ignorePrivacy) => {
 		.trim()
 		.split('\n')
 		.map((line) => line.replace('\t', '  '))
-		.map((line) => line.replace(/[><]\W+/g, ''))
 
 	// Parse WHOIS info for specific TLDs
 
@@ -302,7 +301,7 @@ const parseDomainWhois = (domain, whois, ignorePrivacy) => {
 	if (domain.endsWith('.jp')) {
 		lines = handleJpLines(lines)
 	}
-
+	
 	if (domain.endsWith('.it')) {
 		lines = handleDotIt(lines)
 	}

--- a/src/parsers.js
+++ b/src/parsers.js
@@ -109,7 +109,7 @@ const parseSimpleWhois = (whois) => {
 	return data
 }
 
-const parseDomainWhois = (domain, whois, ignorePrivacy) => {
+const parseDomainWhois = (domain, whois, ignorePrivacy = true) => {
 	// Text saying there's no useful data in a field
 	const noData = [
 		'-',

--- a/src/whoiser.js
+++ b/src/whoiser.js
@@ -120,7 +120,7 @@ const whoisTld = async (query, { timeout = 15000, raw = false, domainThirdLevel 
 	return data
 }
 
-const whoisDomain = async (domain, { host = null, timeout = 15000, follow = 2, raw = false } = {}) => {
+const whoisDomain = async (domain, { host = null, timeout = 15000, follow = 2, raw = false, ignorePrivacy = true} = {}) => {
 	domain = punycode.toASCII(domain)
 	const domainThirdLevel = domain.lastIndexOf('.') !== domain.indexOf('.')
 	const [domainName, domainTld] = splitStringBy(domain.toLowerCase(), domain.lastIndexOf('.'))
@@ -159,7 +159,7 @@ const whoisDomain = async (domain, { host = null, timeout = 15000, follow = 2, r
 
 		try {
 			resultRaw = await whoisQuery({ host, query, timeout })
-			result = parseDomainWhois(domain, resultRaw)
+			result = parseDomainWhois(domain, resultRaw, ignorePrivacy)
 		} catch (err) {
 			result = { error: err.message }
 		}

--- a/src/whoiser.js
+++ b/src/whoiser.js
@@ -120,7 +120,7 @@ const whoisTld = async (query, { timeout = 15000, raw = false, domainTld = '' } 
 	return data
 }
 
-const whoisDomain = async (rawDomain, { host = null, timeout = 15000, follow = 2, raw = false } = {}) => {
+const whoisDomain = async (rawDomain, { host = null, timeout = 15000, follow = 2, raw = false, ignorePrivacy = true } = {}) => {
 	domain = punycode.toASCII(rawDomain)
 	const [domainName, domainTld] = splitStringBy(domain.toLowerCase(), domain.lastIndexOf('.'))
 	let results = {}


### PR DESCRIPTION
I have added a new option to the parseDomainWhois function to allow returning the protected whois data based on the true/false value for the newly added option: ignorePrivacy

The default value is true