### PR TITLE
using whoiser with 'use strict' fails

### DIFF
--- a/src/parsers.js
+++ b/src/parsers.js
@@ -96,7 +96,7 @@ const parseSimpleWhois = (whois) => {
 			} else if (isGroup) {
 				data[isGroup] = group
 			} else {
-				for (key in group) {
+				for (const key in group) {
 					const label = renameLabels[key] || key
 					data[label] = group[key]
 				}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no <!-- please update README.md and CHANGELOG.md files -->
| Deprecations? | no <!-- please update UPGRADE.md and CHANGELOG.md files -->
| Tickets       | 
| License       | MIT

Imported the library in a code which enforce `use strict`. Without this PR I get the following error:

```
ReferenceError: key is not defined
    at /usr/app/dist/index.js:127446:16
    at Array.forEach (<anonymous>)
    at parseSimpleWhois (/usr/app/dist/index.js:127427:61)
    at whoisTld (/usr/app/dist/index.js:127876:20)
    at async whoisDomain (/usr/app/dist/index.js:127900:21)
```
You can ignore the line numbers since it was bundled with esbuild.

<!--
Replace this notice by a short README for your feature/bugfix. This will help people
understand your PR and can be used as a start for the documentation.

Additionally:
 - Always add tests and ensure they pass
 - Never break backward compatibility
 - Bug fixes must be submitted against the lowest maintained branch where they apply
   (lowest branches are regularly merged to upper ones so they get the fixes too.)
 - Features and deprecations must be submitted against master branch
 - Legacy code removals go to the master branch.
-->
