### PR TITLE
Add "encoding" option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,8 @@ declare module 'whoiser' {
 		 */
 		timeout?: number
 
+		encoding?: string
+
 		/**
 		 * How many WHOIS server to query.
 		 * 1 = registry server (faster),

--- a/src/whoiser.js
+++ b/src/whoiser.js
@@ -62,11 +62,12 @@ const whoisHostToIp = {
 	'whois.google.com': '216.239.34.22',
 }
 
-const whoisQuery = ({ host = null, port = 43, timeout = 15000, query = '', querySuffix = '\r\n' } = {}) => {
+const whoisQuery = ({ host = null, port = 43, timeout = 15000, encoding = '', query = '', querySuffix = '\r\n' } = {}) => {
 	return new Promise((resolve, reject) => {
 		let data = ''
 		const socket = net.connect({ host, port }, () => socket.write(query + querySuffix))
 		socket.setTimeout(timeout)
+		if (encoding) socket.setEncoding(encoding)
 		socket.on('data', (chunk) => (data += chunk))
 		socket.on('close', (hadError) => resolve(data))
 		socket.on('timeout', () => socket.destroy(new Error('Timeout')))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #104 
| License       | MIT

How I use it is, if the response can contain special characters in an 8 bit encoding, I set "encoding" to "binary". This is similar to how node-whois module does it. It can be considered a new feature, but I don't think it's significant enough.