### PR TITLE
Add .tr WHOIS server & parsing

### DIFF
--- a/src/whoiser.js
+++ b/src/whoiser.js
@@ -26,6 +26,7 @@ let cacheTldWhoisServer = {
 	ro: 'whois.rotld.ro',
 	rs: 'whois.rnids.rs',
 	so: 'whois.nic.so',
+	tr: 'whois.nic.tr',
 	us: 'whois.nic.us',
 	ws: 'whois.website.ws',
 
@@ -102,7 +103,6 @@ const whoisTld = async (query, { timeout = 15000, raw = false, domainTld = '' } 
 
 	// if no whois server found, search in more sources
 	if (!data.whois) {
-
 		//todo
 		// instead of using `domainTld`, split `query` in domain parts and request info for all tld combinations
 		// example: query="example.com.tld" make 3 requests for "example.com.tld" / "com.tld" / "tld"

--- a/test/domains.js
+++ b/test/domains.js
@@ -120,6 +120,15 @@ describe('#whoiser.domain()', function() {
 				assert.equal(typeof whois['whois.nic.it'][label], 'string', `${label} does not exist, or is not a string`)
 			}
 		})
+
+		it('returns WHOIS for "trabis.gov.tr"', async function () {
+			let whois = await whoiser.domain('trabis.gov.tr')
+			assert.equal(whois['whois.nic.tr']['Domain Name'], 'trabis.gov.tr', 'Domain name doesn\'t match')
+			assert.equal(whois['whois.nic.tr']['Name Server'].length, 5, 'Incorrect number of NS returned')
+			assert.equal(whois['whois.nic.tr']['Registrar'], 'TRABİS KK', 'Registrar name doesn\'t match')
+			assert.equal(whois['whois.nic.tr']['Registrant Name'], 'Bilgi Teknolojileri ve İletişim Kurumu', 'Registrant name doesn\'t match')
+			assert.equal(whois['whois.nic.tr']['Created Date'], '2011-Mar-22', 'Creation date doesn\'t match')
+		})
 	});
 
 });


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| License       | MIT

Add the correct WHOIS server for .tr and parse the data correctly. There are some fields left out in the registrant information because there is no label in the WHOIS response and I could not find any domains that didn't have them anonymized.