### PR TITLE
fix: force ipv4 for whois lookup on port 43 via `net.connect`

### DIFF
--- a/src/whoiser.ts
+++ b/src/whoiser.ts
@@ -75,7 +75,7 @@ const misspelledWhoisServer = {
 export function whoisQuery(host: string, query: string, timeout: number = 5000): Promise<string> {
 	return new Promise((resolve, reject) => {
 		let data = ''
-		const socket = net.connect({ host, port: 43 }, () => socket.write(query + '\r\n'))
+		const socket = net.connect({ host, port: 43, family: 4 }, () => socket.write(query + '\r\n'))
 		socket.setTimeout(timeout)
 		socket.on('data', (chunk) => (data += chunk))
 		socket.on('close', () => resolve(data))


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #97
| License       | MIT

As reported in <https://github.com/LayeredStudio/whoiser/issues/97>, the correct fix is to set `family: 4`.  One should not need to disable IPv6 on their server to fix this.  Instead, this PR should be merged and released/backported.  Thank you.