### PR TITLE
Switch to module punycode-esm

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 		"test": "node --test src/*.test.ts"
 	},
 	"dependencies": {
-		"punycode": "^2.1.1"
+		"punycode-esm": "^1.0.15"
 	},
 	"devDependencies": {
 		"@types/node": "^22.10.2",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import { toASCII } from 'punycode'
+import { toASCII } from 'punycode-esm'
 
 export function splitStringBy(string: string, by: number): [string, string] {
 	return [string.slice(0, by), string.slice(by + 1)]

--- a/src/whoiser.ts
+++ b/src/whoiser.ts
@@ -1,5 +1,5 @@
 import net from 'node:net'
-import { toASCII, toUnicode } from 'punycode'
+import { toASCII, toUnicode } from 'punycode-esm'
 
 import type { DomainWhoisOptions, TldWhoisResponse, WhoisData } from './types.ts'
 import { parseSimpleWhois, parseDomainWhois, whoisDataToGroups } from './parsers.ts'


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| Deprecations? | yes
| Tickets       | Fix #122 
| License       | MIT

This is a minimalistic approach to switch from (deprecated) Node.js core module "punycode" to standard userland module [punycode-esm](https://www.npmjs.com/package/punycode-esm) with the same functionality.
The module [punycode](https://www.npmjs.com/package/punycode) was seemingly used before this change, but in fact it was ineffective, due to ambiguous module names and incorrect syntax used in the import statement. Nowadays, this is a widespread problem, as can be seen in numerous other projects using punycode.
The two easiest solutions - `require("punycode/")` and `import from "punycode.js"` - cannot be used, as this module does not have an ESM version.
Therefore it is appropriate to use a different module, that is feature-compatible with the original. The [punycode-esm](https://www.npmjs.com/package/punycode-esm) module is part of a larger, actively maintained repository and, according to its README, it is an "EMS/Typescript native version of [punycode.js](https://www.npmjs.com/package/punycode)".
